### PR TITLE
Define name of Kubernetes deployment in Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,8 +23,10 @@ env:
   matrix:
     - PROJECT_DIR=server
       DOCKER_IMAGE=rekrysofta/recruitmenttool_server
+      K8S_DEPLOYMENT_NAME=recruitment-tool-server
     - PROJECT_DIR=client
       DOCKER_IMAGE=rekrysofta/recruitmenttool_client
+      K8S_DEPLOYMENT_NAME=recruitment-tool-client
 
 stages:
   - name: script


### PR DESCRIPTION
Fixed a missing definition in the Travis configuration file